### PR TITLE
fix: remove wcatoken from query parameters when using @events endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.29 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4206 : Remove wcatoken from query parameters when using @events endpoint
+  [remdub]
 
 
 1.2.28 (2025-01-09)

--- a/src/imio/events/core/rest/endpoint.py
+++ b/src/imio/events/core/rest/endpoint.py
@@ -44,6 +44,7 @@ class SearchFiltersGet(Service):
 
 class EventsEndpointGet(Service):
     def reply(self):
+        self.request.form.pop("wcatoken", None)
         query = self.request.form.copy()
         query = unflatten_dotted_dict(query)
         return EventsEndpointHandler(self.context, self.request).search(query)


### PR DESCRIPTION
WEB-4206