### PR TITLE
fix: mark event as dirty when modifying selected agendas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.2.37 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4270 : Mark event as dirty when modifying selected agendas
+  Ensures that initial values in the TranslatedAjaxSelectWidget are correctly updated
+  [remdub]
 
 
 1.2.36 (2025-05-27)

--- a/src/imio/events/core/browser/bring_event_into_agendas/agendas.py
+++ b/src/imio/events/core/browser/bring_event_into_agendas/agendas.py
@@ -83,6 +83,7 @@ class BringEventIntoAgendasForm(AutoExtensibleForm, form.Form):
             success_message = _("Agenda(s) correctly added.")
 
         self.context.reindexObject(idxs=["selected_agendas"])
+        self.context._p_changed = 1
         self.status = success_message
         api.portal.show_message(_(self.status), self.request)
 


### PR DESCRIPTION
WEB-4270