### PR TITLE
WEB-4353 : Feat: switch portal timezone from UTC to Europe/Brussels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 1.2.47 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4353 : Feat: switch portal timezone from UTC to Europe/Brussels
+  Upgrade step 1022→1023: reinterpret existing event datetimes as
+  Europe/Brussels wall-clock time (localize without shifting the
+  displayed time), push all published events to ODWB after commit
+  [boulch]
 
 
 1.2.46 (2026-03-20)

--- a/src/imio/events/core/indexers.py
+++ b/src/imio/events/core/indexers.py
@@ -68,7 +68,10 @@ def get_local_category(obj, lang):
         IVocabularyFactory, "imio.events.vocabulary.EventsLocalCategories"
     )
     vocabulary = factory(obj, lang=lang)
-    term = vocabulary.getTerm(obj.local_category)
+    try:
+        term = vocabulary.getTerm(obj.local_category)
+    except LookupError:
+        raise AttributeError
     return term.title
 
 

--- a/src/imio/events/core/profiles/default/metadata.xml
+++ b/src/imio/events/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1022</version>
+  <version>1023</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.gallery:default</dependency>

--- a/src/imio/events/core/profiles/default/registry.xml
+++ b/src/imio/events/core/profiles/default/registry.xml
@@ -60,4 +60,18 @@
     </field>
   </record>
 
+  <record name="plone.portal_timezone">
+    <value>Europe/Brussels</value>
+  </record>
+
+  <record name="plone.available_timezones">
+    <value purge="true">
+      <element>Europe/Brussels</element>
+    </value>
+  </record>
+
+  <record name="plone.first_weekday">
+    <value>0</value>
+  </record>  
+
 </registry>

--- a/src/imio/events/core/rest/endpoint.py
+++ b/src/imio/events/core/rest/endpoint.py
@@ -19,7 +19,10 @@ from zope.component import getMultiAdapter
 import hashlib
 import json
 import logging
+import pytz
 import time
+
+_brussels = pytz.timezone("Europe/Brussels")
 
 logger = logging.getLogger("imio.events.core")
 
@@ -226,10 +229,18 @@ class EventsEndpointHandler(SearchHandler):
     def is_within_range(self, occurrence):
         min_date, max_date = self.request.form.get("event_dates.query", [None, None])
         if min_date and max_date:
-            min_date = datetime.fromisoformat(min_date).replace(tzinfo=timezone.utc)
-            max_date = datetime.fromisoformat(max_date).replace(
-                hour=23, minute=59, second=59, tzinfo=timezone.utc
+            parsed_min = datetime.fromisoformat(min_date)
+            parsed_max = datetime.fromisoformat(max_date)
+            min_date = (
+                parsed_min.astimezone(_brussels)
+                if parsed_min.tzinfo
+                else _brussels.localize(parsed_min)
             )
+            max_date = (
+                parsed_max.astimezone(_brussels)
+                if parsed_max.tzinfo
+                else _brussels.localize(parsed_max)
+            ).replace(hour=23, minute=59, second=59)
             start_date = datetime.fromisoformat(occurrence["start"])
             end_date = datetime.fromisoformat(occurrence["end"])
             return (

--- a/src/imio/events/core/rest/odwb_endpoint.py
+++ b/src/imio/events/core/rest/odwb_endpoint.py
@@ -42,6 +42,7 @@ class OdwbEndpointGet(OdwbBaseEndpointGet):
         batched_lst = [
             self.__datas__[i : i + 1000] for i in range(0, len(self.__datas__), 1000)
         ]
+        response_text = None
         for elem in batched_lst:
             payload = json.dumps(elem)
             response_text = self.odwb_query(url, payload)

--- a/src/imio/events/core/tests/test_rest.py
+++ b/src/imio/events/core/tests/test_rest.py
@@ -152,7 +152,7 @@ class RestFunctionalTest(unittest.TestCase):
         event2.reindexObject()
         response = endpoint.search(query)
         items = response.get("items")
-        self.assertEqual(len(items), 3)
+        self.assertEqual(len(items), 4)
         clear_search_cache(query)
 
         event4.start = datetime(2023, 3, 1, 0, 0)
@@ -162,7 +162,7 @@ class RestFunctionalTest(unittest.TestCase):
         event4.reindexObject()
         response = endpoint.search(query)
         items = response.get("items")
-        self.assertEqual(len(items), 5)
+        self.assertEqual(len(items), 9)
         api.content.transition(event4, "retract")
         event4.reindexObject()
         clear_search_cache(query)
@@ -176,7 +176,7 @@ class RestFunctionalTest(unittest.TestCase):
         api.content.transition(event3, "publish")
         response = endpoint.search(query)
         items = response.get("items")
-        self.assertEqual(len(items), 4)
+        self.assertEqual(len(items), 5)
         clear_search_cache(query)
 
         # Assert list is sorted by start date

--- a/src/imio/events/core/tests/test_utils.py
+++ b/src/imio/events/core/tests/test_utils.py
@@ -163,18 +163,18 @@ class TestAgenda(unittest.TestCase):
         self.assertEqual(expanded_events[-1]["end"], "2022-12-11T13:00:00+00:00")
         events = [
             {
-                "start": "2022-11-13T12:00:00+00:00",
-                "end": "2022-11-13T12:00:00+00:00",
-                "first_start": "2022-11-13T12:00:00+00:00",
-                "first_end": "2022-11-13T12:00:00+00:00",
+                "start": "2022-11-12T23:00:00+00:00",
+                "end": "2022-11-12T23:00:00+00:00",
+                "first_start": "2022-11-12T23:00:00+00:00",
+                "first_end": "2022-11-12T23:00:00+00:00",
                 "recurrence": "RRULE:FREQ=WEEKLY;COUNT=5",
                 "open_end": False,
                 "whole_day": True,
             }
         ]
         expanded_events = expand_occurences(events)
-        self.assertEqual(expanded_events[-1]["start"], "2022-12-11T12:00:00+00:00")
-        self.assertEqual(expanded_events[-1]["end"], "2022-12-11T12:00:00+00:00")
+        self.assertEqual(expanded_events[-1]["start"], "2022-12-10T23:00:00+00:00")
+        self.assertEqual(expanded_events[-1]["end"], "2022-12-11T22:59:59+00:00")
         events = [
             {
                 "start": "2022-11-13T00:00:00+00:00",

--- a/src/imio/events/core/upgrades/configure.zcml
+++ b/src/imio/events/core/upgrades/configure.zcml
@@ -105,6 +105,14 @@
       directory="profiles/1021_to_1022"
       description="Remove useless plone.IBasic beahavior. Replace with imio.smartweb.ia.titles behavior"
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="upgrade_1022_to_1023"
+      title="Upgrade core from 1022 to 1023"
+      directory="profiles/1022_to_1023"
+      description="Switch portal timezone from UTC to Europe/Brussels and migrate existing events"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
       />      
 
   <genericsetup:upgradeStep
@@ -345,6 +353,24 @@
         title="Remove useless plone.IBasic beahavior. Replace with imio.smartweb.ia.titles behavior"
         import_profile="imio.events.core.upgrades:upgrade_1021_to_1022"
         />
-  </genericsetup:upgradeSteps>  
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      source="1022"
+      destination="1023"
+      profile="imio.events.core:default">
+    <genericsetup:upgradeDepends
+        title="Set portal timezone to Europe/Brussels"
+        import_profile="imio.events.core.upgrades:upgrade_1022_to_1023"
+        />
+    <genericsetup:upgradeStep
+        title="Migrate existing events to Europe/Brussels timezone"
+        handler=".upgrades.migrate_events_to_brussels_timezone"
+        />
+    <genericsetup:upgradeStep
+        title="Reset member timezone preferences from UTC to Europe/Brussels"
+        handler=".upgrades.migrate_members_timezone_to_brussels"
+        />
+  </genericsetup:upgradeSteps>
 
 </configure>

--- a/src/imio/events/core/upgrades/profiles/1022_to_1023/registry.xml
+++ b/src/imio/events/core/upgrades/profiles/1022_to_1023/registry.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<registry>
+
+  <record name="plone.portal_timezone">
+    <value>Europe/Brussels</value>
+  </record>
+
+  <record name="plone.available_timezones">
+    <value purge="true">
+      <element>Europe/Brussels</element>
+    </value>
+  </record>
+
+  <record name="plone.first_weekday">
+    <value>0</value>
+  </record>
+
+</registry>

--- a/src/imio/events/core/upgrades/upgrades.py
+++ b/src/imio/events/core/upgrades/upgrades.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
-
+from imio.events.core.contents import IEvent
+from imio.events.core.subscribers import send_to_odwb
 from imio.events.core.utils import reload_faceted_config
 from imio.smartweb.common.upgrades import upgrades
 from plone import api
 from zope.globalrequest import getRequest
 
 import logging
+import pytz
+import transaction
 
 logger = logging.getLogger("imio.events.core")
 
@@ -147,3 +150,59 @@ def reindex_agendas_and_folders(context):
     brains = api.content.find(portal_type=["imio.events.Agenda", "imio.events.Folder"])
     for brain in brains:
         brain.getObject().reindexObject()
+
+
+def migrate_events_to_brussels_timezone(context):
+    _brussels = pytz.timezone("Europe/Brussels")
+    brains = api.content.find(object_provides=IEvent.__identifier__)
+    count = 0
+    batch_size = 100
+    for brain in brains:
+        event = brain.getObject()
+        if getattr(event, "timezone", None) not in ("UTC", "Etc/UTC", None):
+            continue
+        if event.start is None or event.end is None:
+            continue
+        if event.start.year < 100 or event.end.year < 100:
+            logger.warning(f"Skipping event with sentinel date: {brain.getPath()}")
+            continue
+        try:
+            # pytz.timezone.localize() attaches a timezone to a naive datetime
+            event.start = _brussels.localize(event.start.replace(tzinfo=None))
+            event.end = _brussels.localize(event.end.replace(tzinfo=None))
+            event.reindexObject(
+                idxs=["start", "end", "first_start", "first_end", "event_dates"]
+            )
+            count += 1
+        except Exception:
+            logger.exception(f"Failed to migrate event {brain.getPath()}, skipping")
+            continue
+        if count % batch_size == 0:
+            transaction.commit()
+            logger.info(f"Committed batch, {count} events migrated so far")
+    logger.info(f"Migrated {count} events to Europe/Brussels timezone")
+    site = api.portal.get()
+    # Update all published events in ODWB after final commit
+    transaction.get().addAfterCommitHook(send_to_odwb, kws={"obj": site})
+
+
+def migrate_members_timezone_to_brussels(context):
+    """Reset member timezone preferences that are set to UTC.
+
+    User timezone preferences override the portal timezone (plone.app.event
+    checks member.getProperty("timezone") first). Members with UTC set will
+    keep creating events in UTC even after the portal timezone switch.
+    """
+    membership = api.portal.get_tool("portal_membership")
+    members = membership.listMembers()
+    count = 0
+    utc_zones = {"UTC", "Etc/UTC"}
+    for member in members:
+        tz = member.getProperty("timezone", None)
+        if tz in utc_zones or tz is None or tz == "":
+            member.setMemberProperties({"timezone": "Europe/Brussels"})
+            count += 1
+            logger.info(
+                f"Reset timezone for member {member.getId()}: UTC → Europe/Brussels"
+            )
+    logger.info(f"Updated timezone for {count} members")

--- a/src/imio/events/core/utils.py
+++ b/src/imio/events/core/utils.py
@@ -144,30 +144,9 @@ def expand_occurences(events, range="min"):
         if not event["recurrence"]:
             expanded_events.append(event)
             continue
-        # optimize query with "until" to avoid to go through all recurrences
-        # if we want "future events", we get occurences to 1 years in the future
-        # if we want "past events", we get occurences to 1 year in the past
-        until = from_ = None  # datetime.now()
-        until = start_date + timedelta(days=365)
-        # for now min:max is only supported for future events
-        if range == "min":
-            from_ = datetime.now()
-            until = from_ + timedelta(days=365)
-        if range == "min:max":
-            from_ = datetime.now()
-        elif range == "max":
-            from_ = start_date - timedelta(days=365)
-            until = datetime.now()
-        start_dates = recurrence_sequence_ical(
-            start=start_date,
-            recrule=event["recurrence"],
-            from_=from_,
-            until=until,
-        )
-        if is_log_active():
-            logger.warning(
-                f"FROM = {from_} , UNTIL = {until} , range = {range}, start_date = {start_date}, recrule = {event['recurrence']}"
-            )
+        # Compute duration before recurrence_sequence_ical: it uses it in
+        # rset.between(from_ - duration, until) so that ongoing occurrences
+        # (started before now but not yet ended) are included.
         if event["whole_day"]:
             start_day = dateutil.parser.parse(first_start).date()
             end_day = dateutil.parser.parse(first_end).date()
@@ -175,6 +154,31 @@ def expand_occurences(events, range="min"):
             duration = timedelta(days=day_diff, hours=23, minutes=59, seconds=59)
         else:
             duration = end_date - start_date
+        # optimize query with "until" to avoid to go through all recurrences
+        # if we want "future events", we get occurences to 1 years in the future
+        # if we want "past events", we get occurences to 1 year in the past
+        until = from_ = None
+        until = start_date + timedelta(days=365)
+        # for now min:max is only supported for future events
+        if range == "min":
+            from_ = datetime.now(brussels)
+            until = from_ + timedelta(days=365)
+        if range == "min:max":
+            from_ = datetime.now(brussels)
+        elif range == "max":
+            from_ = start_date - timedelta(days=365)
+            until = datetime.now(brussels)
+        start_dates = recurrence_sequence_ical(
+            start=start_date,
+            recrule=event["recurrence"],
+            from_=from_,
+            until=until,
+            duration=duration,
+        )
+        if is_log_active():
+            logger.warning(
+                f"FROM = {from_} , UNTIL = {until} , range = {range}, start_date = {start_date}, recrule = {event['recurrence']}"
+            )
         for occurence_start in start_dates:
             new_event = {**event}
             new_event["start"] = json_compatible(occurence_start)

--- a/src/imio/events/core/utils.py
+++ b/src/imio/events/core/utils.py
@@ -11,7 +11,6 @@ from plone import api
 from plone.event.recurrence import recurrence_sequence_ical
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFPlone.utils import parent
-from pytz import utc
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import noLongerProvides
@@ -19,6 +18,9 @@ from zope.interface import noLongerProvides
 import dateutil
 import logging
 import os
+import pytz
+
+brussels = pytz.timezone("Europe/Brussels")
 
 logger = logging.getLogger("imio.events.core")
 
@@ -103,8 +105,8 @@ def expand_occurences(events, range="min"):
             continue
         first_start = event.get("first_start") or event.get("start")
         first_end = event.get("first_end") or event.get("end")
-        start_date = dateutil.parser.parse(first_start).astimezone(utc)
-        end_date = dateutil.parser.parse(first_end).astimezone(utc)
+        start_date = dateutil.parser.parse(first_start).astimezone(brussels)
+        end_date = dateutil.parser.parse(first_end).astimezone(brussels)
         event["geolocation"] = {
             "latitude": event.get("latitude", ""),
             "longitude": event.get("longitude", ""),
@@ -166,11 +168,15 @@ def expand_occurences(events, range="min"):
             logger.warning(
                 f"FROM = {from_} , UNTIL = {until} , range = {range}, start_date = {start_date}, recrule = {event['recurrence']}"
             )
+        if event["whole_day"]:
+            start_day = dateutil.parser.parse(first_start).date()
+            end_day = dateutil.parser.parse(first_end).date()
+            day_diff = (end_day - start_day).days
+            duration = timedelta(days=day_diff, hours=23, minutes=59, seconds=59)
+        else:
+            duration = end_date - start_date
         for occurence_start in start_dates:
             new_event = {**event}
-            start_time = datetime.combine(datetime.today(), start_date.time())
-            end_time = datetime.combine(datetime.today(), end_date.time())
-            duration = end_time - start_time
             new_event["start"] = json_compatible(occurence_start)
             new_event["end"] = json_compatible(occurence_start + duration)
             expanded_events.append(new_event)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal timezone switched from UTC to Europe/Brussels; existing event datetimes are reinterpreted as local wall-clock time and published events are re-synced.
  * Member timezones set to Europe/Brussels and available timezones restricted to Europe/Brussels.

* **Bug Fixes**
  * API date-range handling aligned with Europe/Brussels timezone.
  * ODWB endpoint now returns a defined response even when no data is batched.

* **Chores**
  * Core version updated to 1023 with an associated upgrade profile.

* **Tests**
  * Recurrence expansion test adjusted for all-day event boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->