### PR TITLE
WEB-4427 : Fix a bug when whole_day for only 1 day

### DIFF
--- a/.github/workflows/plone-package-test-gha.yml
+++ b/.github/workflows/plone-package-test-gha.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: gha-runners-smartweb
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout codebase
       uses: actions/checkout@v4

--- a/src/imio/events/core/tests/test_rest.py
+++ b/src/imio/events/core/tests/test_rest.py
@@ -759,6 +759,56 @@ class RestFunctionalTest(unittest.TestCase):
         # 00:00 → True). 4 future ones expected: 04-29, 05-06, 05-13, 05-20.
         self.assertEqual(len(weekly_items), 4)
 
+    @freeze_time("2026-05-13")
+    def test_whole_day_event_with_same_start_end_returns_correct_dates(self):
+        # Bug observé côté section (@sections/events/view.py) : un événement
+        # whole_day 16/05 02:00 → 16/05 02:00 s'affiche du 15/05 au 17/05.
+        # Ce test pin ce que l'API @events renvoie réellement pour ce cas,
+        # afin de localiser si le bug est ici ou dans le consommateur.
+        event = api.content.create(
+            container=self.agenda,
+            type="imio.events.Event",
+            id="whole_day_same_start_end",
+            title="Whole Day Same Start End",
+        )
+        event.start = datetime(2026, 5, 16, 2, 0)
+        event.end = datetime(2026, 5, 16, 2, 0)
+        event.whole_day = True
+        event.reindexObject()
+        api.content.transition(event, "publish")
+
+        endpoint = EventsEndpointHandler(self.portal, self.request)
+        query = {"b_size": 10, "b_start": 0}
+        try:
+            response = endpoint.search(query)
+        finally:
+            clear_search_cache(query)
+
+        items = [
+            i
+            for i in response.get("items", [])
+            if i["title"] == "Whole Day Same Start End"
+        ]
+        self.assertEqual(len(items), 1, f"event not found in response: {response}")
+        item = items[0]
+        print(
+            f"\nDIAG whole_day 16/05 02:00→02:00: "
+            f"start={item.get('start')!r}, end={item.get('end')!r}"
+        )
+        # Expected: l'événement doit rester ancré au 16/05.
+        # start doit être le 16/05 (pas le 15/05).
+        self.assertIn(
+            "2026-05-16",
+            item["start"],
+            f"start a glissé hors du 16/05: {item['start']!r}",
+        )
+        # end doit être start + 23h59m59s — donc encore le 16/05 (pas le 17/05).
+        self.assertIn(
+            "2026-05-16",
+            item["end"],
+            f"end a débordé au-delà du 16/05: {item['end']!r}",
+        )
+
 
 # <audit>
 #   <file>test_rest.py</file>

--- a/src/imio/events/core/tests/test_utils.py
+++ b/src/imio/events/core/tests/test_utils.py
@@ -190,6 +190,56 @@ class TestAgenda(unittest.TestCase):
         self.assertEqual(expanded_events[-1]["start"], "2022-12-11T00:00:00+00:00")
         self.assertEqual(expanded_events[-1]["end"], "2022-12-11T23:59:59+00:00")
 
+    @freeze_time("2026-05-13")
+    def test_expand_occurences_whole_day_non_recurring(self):
+        # Régression: événement whole_day non-récurrent, stocké correctement
+        # par Plone comme jour complet en TZ locale Brussels:
+        #   start = 16/05 00:00 Brussels (= 15/05 22:00 UTC, CEST)
+        #   end   = 16/05 23:59 Brussels (= 16/05 21:59 UTC, CEST)
+        # Avant fix: (end-start) + 23h59m59s ≈ 48h → end débordait au 17/05.
+        # Après fix: end doit rester sur le jour de end_date (= 16/05 Brussels).
+        events = [
+            {
+                "start": "2026-05-15T22:00:00+00:00",
+                "end": "2026-05-16T21:59:00+00:00",
+                "first_start": "2026-05-15T22:00:00+00:00",
+                "first_end": "2026-05-16T21:59:00+00:00",
+                "recurrence": None,
+                "open_end": False,
+                "whole_day": True,
+            }
+        ]
+        expanded_events = expand_occurences(events)
+        self.assertEqual(len(expanded_events), 1)
+        event = expanded_events[0]
+        # start: inchangé, on garde le moment réel d'origine
+        self.assertEqual(event["start"], "2026-05-15T22:00:00+00:00")
+        # end: fin-de-journée Brussels du jour de end_date (16/05 Brussels)
+        # = 16/05 23:59:59 Brussels = 16/05 21:59:59 UTC
+        self.assertEqual(event["end"], "2026-05-16T21:59:59+00:00")
+
+    @freeze_time("2026-05-13")
+    def test_expand_occurences_whole_day_multi_day_non_recurring(self):
+        # Événement whole_day non-récurrent qui couvre plusieurs jours (15→17/05
+        # en TZ Brussels). end doit pointer la fin du DERNIER jour.
+        events = [
+            {
+                "start": "2026-05-14T22:00:00+00:00",  # = 15/05 00:00 Brussels CEST
+                "end": "2026-05-17T21:59:00+00:00",  # = 17/05 23:59 Brussels CEST
+                "first_start": "2026-05-14T22:00:00+00:00",
+                "first_end": "2026-05-17T21:59:00+00:00",
+                "recurrence": None,
+                "open_end": False,
+                "whole_day": True,
+            }
+        ]
+        expanded_events = expand_occurences(events)
+        self.assertEqual(len(expanded_events), 1)
+        event = expanded_events[0]
+        self.assertEqual(event["start"], "2026-05-14T22:00:00+00:00")
+        # end-of-day Brussels du 17/05 = 17/05 21:59:59 UTC
+        self.assertEqual(event["end"], "2026-05-17T21:59:59+00:00")
+
     def test_get_start_date(self):
         event = {
             "start": "2022-11-13T12:00:00+00:00",

--- a/src/imio/events/core/utils.py
+++ b/src/imio/events/core/utils.py
@@ -134,13 +134,13 @@ def expand_occurences(events, range="min"):
         event["start"] = json_compatible(start_date)
         event["end"] = json_compatible(end_date)
         if event["whole_day"]:
-            if end_date:
-                duration = (end_date - start_date) + timedelta(
-                    hours=23, minutes=59, seconds=59
-                )
-            else:
-                duration = timedelta(hours=23, minutes=59, seconds=59)
-            event["end"] = json_compatible(start_date + duration)
+            # whole_day ⇒ fin = 23:59:59 du dernier jour en TZ locale (Brussels).
+            # L'ancienne formule (end-start)+24h doublait la durée quand Plone
+            # avait déjà stocké end à 23:59 du dernier jour.
+            end_basis = end_date if end_date else start_date
+            event["end"] = json_compatible(
+                end_basis.replace(hour=23, minute=59, second=59, microsecond=0)
+            )
         if not event["recurrence"]:
             expanded_events.append(event)
             continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whole-day events with matching start and end dates to maintain correct date anchoring.
  * Corrected multi-day whole-day event end date calculations.

* **Tests**
  * Added regression tests for whole-day event date handling.

* **Chores**
  * Updated CI Python version matrix to 3.12 and 3.13.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/imio.events.core/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->